### PR TITLE
Fix: Add null check before accessing o.added[0].promise

### DIFF
--- a/src/test/getHandlerPr.ts
+++ b/src/test/getHandlerPr.ts
@@ -19,6 +19,9 @@ export function getHandlerPr(evt: NonPostableEvt<any>, run: ()=> void): Promise<
         handlersAfter
     );
 
+    if (o.added.length === 0) {
+        throw new Error("No handlers were added during the test run");
+    }
     return o.added[0].promise;
 
 }


### PR DESCRIPTION
## Bug Fix: Missing null check in getHandlerPr

### Problem
The `getHandlerPr` function in `src/test/getHandlerPr.ts` accesses `o.added[0].promise` without first checking if the `added` array has any elements. If the test run does not add any handlers, `o.added` will be an empty array, and accessing `[0]` will return `undefined`, causing a crash when trying to access `.promise`.

### Solution
Added a length check on `o.added` before accessing the first element. If no handlers were added, the function now throws a descriptive error instead of crashing with an undefined property access.

### Changes
- Modified `src/test/getHandlerPr.ts`
- Added check: `if (o.added.length === 0)` before accessing `o.added[0].promise`
- Throws `Error("No handlers were added during the test run")` if array is empty

### Testing
This is a test utility function, so the fix ensures that tests fail with a clear error message when they don't add any handlers, rather than crashing with an obscure undefined property access error.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.